### PR TITLE
Fix MySQL tests on PHP 7.0.0+

### DIFF
--- a/PHP/standardtests.php
+++ b/PHP/standardtests.php
@@ -66,28 +66,28 @@
 		// MySQL Database
 		if ($test == "mysql-ping") {
 			set_time_limit(0);
-			$conn = mysql_connect($host, $dbuser, $dbpass); // Make a connection
-			if (!mysql_ping($conn)) throwStatus("4","Failed to ping, connect or login on the db-server");
+			$conn = mysqli_connect($host, $dbuser, $dbpass); // Make a connection
+			if (!mysqli_ping($conn)) throwStatus("4","Failed to ping, connect or login on the db-server");
 			else throwStatus("0", getRunningTime()); // OK
 		}
 
 		if ($test == "mysql-select") {
 			set_time_limit(0);
-			$conn =mysql_connect($host, $dbuser, $dbpass); // Make a connection
+			$conn =mysqli_connect($host, $dbuser, $dbpass); // Make a connection
 			if (!$conn) throwStatus("4","Failed to connect or login on the db-server");
-			$db   = mysql_select_db($database); // Select the database
+			$db   = mysqli_select_db($conn, $database); // Select the database
 			if (!$db) throwStatus("4","Failed to select the database");
 			else throwStatus("0", getRunningTime()); // OK
 		}
 
 		if ($test == "mysql-execTable") {
 			set_time_limit(0);
-			$conn =mysql_connect($host, $dbuser, $dbpass); // Make a connection
+			$conn =mysqli_connect($host, $dbuser, $dbpass); // Make a connection
 			if (!$conn) throwStatus("4","Failed to connect or login on the db-server");
-			$db   = mysql_select_db($database); // Select the database
+			$db   = mysqli_select_db($conn, $database); // Select the database
 			if (!$db) throwStatus("4", "Failed to select the database");
 			$sql  = "SELECT * FROM $dbtable LIMIT 50"; // Try to fetch some data
-			$res = mysql_query($sql) or die("4"); // Try to read this data
+			$res = mysqli_query($conn, $sql) or die("4"); // Try to read this data
 			if (!$res) throwStatus("4", getRunningTime()); // Oops
 			else throwStatus("0", getRunningTime()); // OK
 		}


### PR DESCRIPTION
The interface used by SemC's MySQL tests was deprecated in PHP 5.5 and removed in PHP 7.
This PR replaces these functions with alternatives supported on PHP 5 and up.

- [`mysql_connect`](https://www.php.net/manual/en/function.mysql-connect) –> [`mysqli_connect`](https://www.php.net/manual/en/function.mysqli-connect.php)
- [`mysql_ping `](https://www.php.net/manual/en/function.mysql-ping) –> [`mysqli_ping `](https://www.php.net/manual/en/mysqli.ping.php)
- [`mysql_select_db `](https://www.php.net/manual/en/function.mysql-select-db) –> [`mysqli_select_db `](https://www.php.net/manual/en/mysqli.select-db.php)
- [`mysql_query `](https://www.php.net/manual/en/function.mysql-query) –> [`mysqli_query `](https://www.php.net/manual/en/mysqli.query.php)